### PR TITLE
Fix #70: MarkovBot will no longer learn empty messages

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -11,7 +11,7 @@ filters = list(filter(None, [PATTERNS.get(f, '') for f in settings.FILTERS]))
 
 def message_filter(message):
     # If the message has no text, we just ignore it.
-    if message.text is None:
+    if not message.text:
         return False
 
     return not any(re.search(f, message.text, re.I) for f in filters)

--- a/filters.py
+++ b/filters.py
@@ -10,4 +10,8 @@ filters = list(filter(None, [PATTERNS.get(f, '') for f in settings.FILTERS]))
 
 
 def message_filter(message):
+    # If the message has no text, we just ignore it.
+    if message.text is None:
+        return False
+
     return not any(re.search(f, message.text, re.I) for f in filters)

--- a/markov.py
+++ b/markov.py
@@ -157,14 +157,20 @@ def start(message):
 
 @bot.message_handler(func=message_filter)
 def handle_message(message):
-    update_model(message)
     if f'@{bot.get_me().username}' in message.text:
         generate_sentence(message, reply=True)
+    else:
+        update_model(message)
 
 
 def update_model(message):
     chat_id = str(message.chat.id)
     chat_messages = db.find_one(chat_id=chat_id) or {}
+
+    if message.text is None or message.text is '':
+        logger.debug("Received empty message, not altering the database.")
+        return
+
     db.upsert({
         'chat_id': chat_id,
         'text': '\n'.join([chat_messages.get('text', ''), message.text])

--- a/markov.py
+++ b/markov.py
@@ -157,10 +157,9 @@ def start(message):
 
 @bot.message_handler(func=message_filter)
 def handle_message(message):
+    update_model(message)
     if f'@{bot.get_me().username}' in message.text:
         generate_sentence(message, reply=True)
-    else:
-        update_model(message)
 
 
 def update_model(message):

--- a/test/test_filters.py
+++ b/test/test_filters.py
@@ -7,3 +7,8 @@ def test_message_filter(message):
     assert filters.message_filter(message) is True
     message.text = 'Hello, World'
     assert filters.message_filter(message) is False
+
+
+def test_empty_message(message):
+    message.text = None
+    assert filters.message_filter(message) is False

--- a/test/test_markov.py
+++ b/test/test_markov.py
@@ -7,8 +7,8 @@ from unittest import mock
 @mock.patch('markov.bot')
 @mock.patch('markov.db')
 def test_handle_message(
-    mock_db, mock_bot, mock_update_model,
-    mock_generate_sentence, message
+        mock_db, mock_bot, mock_update_model,
+        mock_generate_sentence, message
 ):
     mock_get_me = mock.Mock()
     mock_get_me.return_value.username = 'markov_bot'
@@ -23,8 +23,8 @@ def test_handle_message(
 @mock.patch('markov.bot')
 @mock.patch('markov.db')
 def test_handle_message_with_mention(
-    mock_db, mock_bot, mock_update_model,
-    message
+        mock_db, mock_bot, mock_update_model,
+        message
 ):
     mock_db.find_one.return_value = {'text': 'bla bla bla'}
     message.text = 'hello, @markov_bot!'
@@ -51,6 +51,16 @@ def test_update_model(mock_db, mock_bot, message):
     }, ['chat_id'])
 
 
+@mock.patch('markov.bot')
+@mock.patch('markov.db')
+def test_update_model_on_empty_message(mock_db, mock_bot, message):
+    message.text = None
+    mock_db.find_one.return_value = ''
+
+    markov.update_model(message)
+    assert not mock_db.upsert.called
+
+
 @mock.patch('markov.db')
 def test_get_model(mock_db, message):
     mock_db.find_one.return_value = {'text': 'bla bla bla'}
@@ -73,7 +83,7 @@ def test_generate_sentence(mock_model, mock_bot, message):
 @mock.patch('markov.db')
 @mock.patch('markov.telebot.types.ReplyKeyboardMarkup')
 def test_remove_messages_ask_confirm(
-    mock_markup, mock_db, mock_bot, mock_model, message
+        mock_markup, mock_db, mock_bot, mock_model, message
 ):
     message.text = '/remove'
     mock_bot.get_chat_administrators.return_value = [message]


### PR DESCRIPTION
Fixes #70.

If a message is empty, the filter will refuse to process it, instead returning `False`, as though it were on the illegal filter list. Additionally, the learning system itself will not process cases where the message content is None or simply blank.

