### PR TITLE
Removes quotes from text before create markov chain

### DIFF
--- a/markov/speech.py
+++ b/markov/speech.py
@@ -76,7 +76,7 @@ def new_model(text):
     Cls = PosifiedText if settings.MODEL_LANG else markovify.NewlineText
     model = None
     try:
-        model = Cls(text, retain_original=False)
+        model = Cls(re.sub(r'["\']', '', text), retain_original=False)
     except KeyError:
         logger.error(f'cannot create a chain from {text}')
     return model


### PR DESCRIPTION
For some reason the creation of a Markov chain model using a text with quotes was failing, for now this must solve the problem.