### PR TITLE
Add new settings for markovify library

### DIFF
--- a/markov/settings.py
+++ b/markov/settings.py
@@ -18,6 +18,9 @@ class Settings:
     ADMIN_CHAT_ID = config('ADMIN_CHAT_ID', default='')
     FILTERS = config('FILTERS', default='', cast=Csv())
     MODEL_LANG = config('MODEL_LANG', default='', cast=Csv())
+    RETAIN_ORIG = config('RETAIN_ORIG', default=True, cast=bool)
+    MAX_OVERLAP_RATIO = config('MAX_OVERLAP_RATIO', default=0.7, cast=float)
+    TRIES = config('TRIES', default=50, cast=int)
 
 
 settings = Settings()

--- a/test/test_speech.py
+++ b/test/test_speech.py
@@ -111,7 +111,7 @@ def test_get_model(mock_db, one_found, message):
     mock_db.find_one.return_value = one_found
     model = speech.get_model(message.chat)
     assert mock_db.find_one.called
-    assert isinstance(model, speech.PosifiedText)
+    assert isinstance(model, speech.markovify.NewlineText)
 
 
 @mock.patch('markov.speech.db')


### PR DESCRIPTION
The new settings available are:

* **RETAIN_ORIG** - Keeps the source text used to create the Markov chain.
* **MAX_OVERLAP_RATIO*** - Tells how much similar a new sentence can be compared to original texts.
* **TRIES** - Tells how many times the markovify library should try make a new sentence.

\* Requires RETAIN_ORIG defined as True.