### PR TITLE
Add flag to control Markov chain's growth

### DIFF
--- a/markov/settings.py
+++ b/markov/settings.py
@@ -21,6 +21,7 @@ class Settings:
     RETAIN_ORIG = config('RETAIN_ORIG', default=True, cast=bool)
     MAX_OVERLAP_RATIO = config('MAX_OVERLAP_RATIO', default=0.7, cast=float)
     TRIES = config('TRIES', default=50, cast=int)
+    GROW_CHAIN = config('GROW_CHAIN', default=False, cast=bool)
 
 
 settings = Settings()


### PR DESCRIPTION
It gives the ability to control the Markov chain's growth by setting a flag as true or false. By default its value is set to false.

When GROW_CHAIN flag is false the Markov chain update process takes the MESSAGE_LIMIT setting value to limit the amount of messages it will be kept and used to build the chain.

On the other hand, when GROW_CHAIN is set to true all new messages will be appended to the existing chain.