### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ script:
     - make test
 after_success:
     - codecov
+env:
+    - PIPENV_IGNORE_VIRTUALENVS=1

--- a/Pipfile
+++ b/Pipfile
@@ -24,4 +24,4 @@ pytest = "*"
 "flake8" = "*"
 
 [requires]
-python_full_version = "3.7.1"
+python_full_version = "3.7"


### PR DESCRIPTION
- Set **PIPENV_IGNORE_VIRTUALENVS** in .travis.yml config file forcing Travis to create a new virtual environment.
- Change **python_full_version** in Pipfile removing the _patch_ part (Travis still using 3.7-dev and can't create a new environment for 3.7.x).

Solves issue #216