### PR TITLE
Fix pipenv command in travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.7.2"
 install:
     - pip install pipenv --upgrade
-    - pipenv install --dev
+    - pipenv sync -d
 script:
     - make test
 after_success:


### PR DESCRIPTION
The command `$ pipenv install` actually installs the last available packages for each dependency in Pipfile when what we want is install the version of the packages listed in Pipfile.lock.